### PR TITLE
Strip CR from parsed document

### DIFF
--- a/lib/slime/preprocessor.ex
+++ b/lib/slime/preprocessor.ex
@@ -11,6 +11,7 @@ defmodule Slime.Preprocessor do
     document
     |> expand_tabs
     |> remove_trailing_newlines
+    |> convert_crlf_to_lf
     |> split_into_lines
   end
 
@@ -24,5 +25,9 @@ defmodule Slime.Preprocessor do
 
   defp split_into_lines(document) do
     String.split(document, "\n")
+  end
+  
+  defp convert_crlf_to_lf(document) do
+    String.replace(document, ~r/\r/, "")
   end
 end


### PR DESCRIPTION
Remove all carriage return characters from parsed document to matanin compatibility with editors working under Windows operating system. 
For Windows CRLF is default line ending, and simplest way to handle that is to simply remove all CR characters by using regex. If document has only LF line endings then `convert_crlf_to_lf` will simply return original document, because nothing is going to be replaced.
